### PR TITLE
Fix copy errors (CSV expansion, duplicate heading, tally/pieces)

### DIFF
--- a/en/step_4.md
+++ b/en/step_4.md
@@ -8,7 +8,7 @@ The chart looks good, but nearly 150 nations have competed in the Olympics. Inst
 >
 > ### CSV files
 >
-> CSV stands for **C**omma-**S**eparated **V**alue.
+> CSV stands for **C**omma-**S**eparated **V**alues.
 > There are several `.csv` files included in this starter project that contain the data you need for your charts.
 >
 > Open `medals.csv` and look at the data in it. See how each line has a team name and the number of medals they have won, separated by a comma.

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -2,8 +2,6 @@
 
 Use different files to compare data
 
-## Investigate with data
-
 Now your program can draw charts from files of data. You can use it on different files to compare their charts to see what you can learn.
 
 ![A bar chart showing the populations of many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="300px"}

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -27,7 +27,7 @@ In this step, change how your chart looks, or what data it uses.
 >
 > Update the code that reads from `medals.csv` to read from your new file.
 >
-> These files have more than one column of numbers. Use indexes on the `tally` list to choose which to add to your chart.
+> These files have more than one column of numbers. Use indexes on the `pieces` list to choose which to add to your chart.
 >
 > The carbon dioxide data uses numbers with decimals. To convert them from text strings, you'll need to use `float()` instead of `int()`.
 


### PR DESCRIPTION
Follow-up copy fixes to the RPF conversion, resolved before merging (no outstanding review notes):

- **step_4**: "Comma-Separated Value" → "Comma-Separated Values"
- **step_7**: removed the duplicate `## Investigate with data` heading; its text now sits as intro under the `## Investigating data` task heading
- **step_9 (challenge)**: referred to a `tally` list, but the steps have the learner build the list as `pieces` — corrected to `pieces`

🤖 Generated with [Claude Code](https://claude.com/claude-code)