### PR TITLE
Fix step structure: ## Step N for multi-task steps + restore 'Now run your code'

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,15 +1,16 @@
 ## Make a chart
 
-Use Python to create and display a chart
+Use Python to create and display a chart.
 
 The starter project already has some code to import the `pygal` library, which you will use to draw your chart.
 
 ```python filename="main.py" line_numbers="true" line_number_start="1" line_highlights="1"
 
 from pygal import Bar
+
 ```
 
-### Give the chart a name
+## Step 1
 
 Add a title for your chart below the `# Create a chart` comment.
 
@@ -18,7 +19,7 @@ Add a title for your chart below the `# Create a chart` comment.
 chart = Bar(title='Olympic medals')
 ```
 
-### Display the chart
+## Step 2
 
 Call `chart.render()` to display the chart.
 
@@ -26,6 +27,8 @@ Call `chart.render()` to display the chart.
 # Display the chart
 chart.render()
 ```
+
+## Now run your code
 
 Run your code to see the chart. It will be empty because it doesn't have data yet.
 
@@ -35,7 +38,7 @@ Run your code to see the chart. It will be empty because it doesn't have data ye
 >
 > If you see an error about `Bar()` or `chart.render()` being `not defined`:
 >
-> - If the error is for `Bar()`, make sure it has an uppercase B at the start, and brackets at the end
-> - If the error is for `chart.render()`, check that it has the `.` between `chart` and `render`, as well as the brackets at the end
+>  - If the error is for `Bar()`, make sure it has an uppercase B at the start, and brackets at the end
+>  - If the error is for `chart.render()`, check that it has the `.` between `chart` and `render`, as well as the brackets at the end
 >
 > If you are not using the Raspberry Pi code editor, and the graph hasn't appeared when you run your code, replace `chart.render()` with `chart.render_in_browser()`.

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,14 +1,12 @@
 ## Add data
 
-Get data into your chart
-
-### Add some data
+Get data into your chart.
 
 Python can store related data as a **list**. You can create lists by using square brackets `[]`. Items in a list are separated with commas.
 
-Create three lists of data to show on your chart.
+## Step 1
 
-Each list will store a nation's name and the number of medals won by that nation.
+Create three lists of data to show on your chart. Each list will store a nation's name and the number of medals won by that nation.
 
 ```python filename="main.py" line_numbers="true" line_number_start="7" line_highlights="8-10"
 # Add data to the chart
@@ -19,7 +17,7 @@ fr = ['France', 751]
 
 When you store something in a list, it gets an **index**. An index is a number that tells you an item's position in a list. List indexes start from `0`, instead of `1`.
 
-### Make lists
+## Step 2
 
 You can get an item from a list by its index. For example, `my_list[3]` will get the **fourth** item in `my_list`, because indexes start at `0`.
 
@@ -31,6 +29,8 @@ chart.add(gb[0], gb[1])
 chart.add(fr[0], fr[1])
 ```
 
+## Now run your code
+
 Run your code to see the chart.
 
 ![A bar chart showing the medals won by the United States, Great Britain, and France.](images/short_list.png){:width="300px"}
@@ -38,6 +38,5 @@ Run your code to see the chart.
 > [!DEBUG]
 >
 > If you see a message about an `IndexError`, your code is trying to get a value from a list index that doesn't exist (e.g. `us[2]`). To fix this:
->
-> - Check each of your `chart.add` lines to be sure you are only using `0` and `1` as indexes.
-> - Check the lines where you created your lists. Make sure each list has two items, separated by a comma.
+>  - Check each of your `chart.add` lines to be sure you are only using `0` and `1` as indexes.
+>  - Check the lines where you created your lists. Make sure each list has two items, separated by a comma.

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -15,7 +15,10 @@ chart.add(gb[0], gb[1])
 chart.add(fr[0], fr[1])
 chart.add(ge[0], ge[1])
 chart.add(ch[0], ch[1])
+
 ```
+
+## Now run your code
 
 Run your code to see the updated chart. Try clicking on the United States' name. Then watch the scale of the chart change.
 
@@ -24,6 +27,5 @@ Run your code to see the updated chart. Try clicking on the United States' name.
 > [!DEBUG]
 >
 > If you see a message about an `IndexError`, your code is trying to get a value from a list index that doesn't exist (e.g. `fr[2]`). To fix this:
->
-> - Check each of your `chart.add` lines to be sure you are only using `0` and `1` as indexes.
-> - Check the lines where you created your lists. Make sure each list has two items, separated by a comma.
+>  - Check each of your `chart.add` lines to be sure you are only using `0` and `1` as indexes.
+>  - Check the lines where you created your lists. Make sure each list has two items, separated by a comma.

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,21 +1,25 @@
 ## Large datasets
 
-Load bigger datasets from a CSV file
+Load bigger datasets from a CSV file.
 
 The chart looks good, but nearly 150 nations have competed in the Olympics. Instead of typing them all, you can load the data from a file.
 
 > [!INFO]
 >
-> ### CSV files
+> ## CSV files
 >
 > CSV stands for **C**omma-**S**eparated **V**alues.
 > There are several `.csv` files included in this starter project that contain the data you need for your charts.
->
-> Open `medals.csv` and look at the data in it. See how each line has a team name and the number of medals they have won, separated by a comma.
+
+## Step 1
+
+Open `medals.csv` and look at the data in it. See how each line has a team name and the number of medals they have won, separated by a comma.
 
 ![The Raspberry Pi code editor with medals file highlighted and open, displaying a list of countries and medal numbers separated with a comma.](images/medals-tab.png)
 
 You'll need to turn each line of `medals.csv` into a text string and a number in Python, like in the lists you made.
+
+## Step 2
 
 Click on the **main.py** tab.
 
@@ -34,7 +38,9 @@ with open('medals.csv') as f:
         print(line)
 ```
 
-**Run** your code and look at the text it prints out in the **Text output** tab.
+## Now run your code
+
+Run your code and look at the text it prints out in the **Text output** tab.
 
 Notice that each line has two values, separated by commas.
 

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,6 +1,6 @@
 ## Split into lists
 
-Use `split(',')` to make a new list item every time there is a comma
+Use `split(',')` to make a new list item every time there is a comma.
 
 Each string that your loop prints is made up of two pieces separated by a comma. Your `chart.add()` function needs each of those pieces as separate inputs.
 
@@ -22,7 +22,9 @@ with open('medals.csv') as f:
 >
 > You may notice that the second item has `\n` or `\r\n` at the end. This tells the computer it has reached the end of the line in a file.
 
-**Run** your code and look at the text it prints out in the **Text output** tab. Each line should be a list with two items.
+## Now run your code
+
+Run your code and look at the text it prints out in the **Text output** tab. Each line should be a list with two items.
 
 ![Many lists, each with two items, printed out.](images/tally.png){:width="400px"}
 

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,6 +1,6 @@
 ## Load CSV into chart
 
-Use `int()` to convert a string to a number and load it into a chart
+Use `int()` to convert a string to a number and load it into a chart.
 
 Load your data into the chart as part of your `for` loop. `team` is a string, so it can be used as a label on the chart. `medals` is currently a string, but it needs to be converted to a number. You can use `int()` to do this.
 
@@ -19,6 +19,8 @@ with open('medals.csv') as f:
 >
 > You can now use `#` to turn `print(pieces)` into a comment too.
 
+## Now run your code
+
 Run your code and look at the chart it creates. Try hovering over some of the bars, or clicking on the names of teams to add and remove them from the chart.
 
 ![A bar chart showing the medal counts of many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="400px"}
@@ -28,7 +30,6 @@ Run your code and look at the chart it creates. Try hovering over some of the ba
 > If your chart is empty, check that you have `int(medals)` in your `chart.add()`.
 >
 > If you see a message about an `IndexError`, your code is trying to get a value from a list index that doesn't exist (e.g. `pieces[2]`). To fix this:
->
-> - Check each of your `team` and `medals` variables to be sure you are only using `0` and `1` as indexes.
-> - Check the printed `pieces` lists to be sure they have two items: `['Tonga', '1\n']`, not `['Tonga,1\n']`. If they don't, then check that you have `','` in the `()` of `line.split()`.
-> - Check you do not have a blank line at the bottom of your .csv file.
+>  - Check each of your `team` and `medals` variables to be sure you are only using `0` and `1` as indexes.
+>  - Check the printed `pieces` lists to be sure they have two items: `['Tonga', '1\n']`, not `['Tonga,1\n']`. If they don't, then check that you have `','` in the `()` of `line.split()`.
+>  - Check you do not have a blank line at the bottom of your .csv file.

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,28 +1,30 @@
 ## Investigating data
 
-Use different files to compare data
+Use different files to compare data.
 
 Now your program can draw charts from files of data. You can use it on different files to compare their charts to see what you can learn.
 
-![A bar chart showing the populations of many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="300px"}
-
-### Who has the most medals?
-
-Look at the chart you've made. The taller a bar is, the more medals that team has won. Hover the mouse over some of the tallest bars and notice which teams they belong to.
-
-![A bar chart showing the populations of many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="500px"}
-
-Why might they have the most medals?
-
-A good idea might be to look at both the population and wealth of teams, to see if there is any sort of pattern.
+![A bar chart showing the medals won by many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="300px"}
 
 > [!INFO]
 >
-> **Data analysis:** People have done these kinds of investigations since long before computers were invented. For example, in the 1850s, Florence Nightingale, a nurse, used charts and graphs to show the importance of disease prevention in caring for the sick.
+> ## Who has the most medals?
+>
+> Look at the chart you've made. The taller a bar is, the more medals that team has won. Hover the mouse over some of the tallest bars and notice which teams they belong to.
+>
+> ![A bar chart showing the medals won by many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/adjust_chart.gif){:width="500px"}
+>
+> Why might they have the most medals?
+>
+> A good idea might be to look at both the population and wealth of teams, to see if there is any sort of pattern.
+
+> [!INFO]
+>
+> ## Data analysis
+>
+> People have done these kinds of investigations since long before computers were invented. For example, in the 1850s, Florence Nightingale, a nurse, used charts and graphs to show the importance of disease prevention in caring for the sick.
 >
 > ![Florence Nightingale's chart of causes of mortality.](images/nightingale.jpeg){:width="300px"}
-
-### Population sizes
 
 A file, called `pop.csv`, with data on the populations of different countries, is part of the starter project. Because the data in `pop.csv` is also made up of a text string and a number, you can re-use your code with only small changes.
 
@@ -41,6 +43,8 @@ with open('pop.csv') as f:
         population = pieces[1]
         chart.add(team, int(population))  # Make population a number
 ```
+
+## Now run your code
 
 Now run your program and look at the chart it draws.
 

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -1,14 +1,18 @@
 ## GDP data
 
-Draw a chart based on the GDP data
-
-### Wealth
-
-A file called `gdp.csv` is part of the starter project. It has data on the annual GDP of different countries. Just like with `pop.csv`, you'll only need to make small changes to use it.
+Draw a chart based on the GDP data.
 
 > [!INFO]
 >
-> **GDP** is the Gross Domestic Product. It measures the value, in money, of everything produced in an area over a given time period. It can measure how rich an area is.
+> ## Wealth
+>
+> A file called `gdp.csv` is part of the starter project. It has data on the annual GDP of different countries. Just like with `pop.csv`, you'll only need to make small changes to use it.
+
+> [!INFO]
+>
+> ## GDP
+>
+> GDP is the Gross Domestic Product. It measures the value, in money, of everything produced in an area over a given time period. It can measure how rich an area is.
 
 Change the chart title, the file you are opening, and the category name to draw a chart based on the GDP data in `gdp.csv`.
 
@@ -28,20 +32,24 @@ with open('gdp.csv') as f:
         chart.add(team, float(gdp))  # Make GDP a number
 ```
 
+## Now run your code
+
 Now run your program and look at the chart it draws.
 
 ![A bar chart showing the GDP of many nations. Information appears when the mouse hovers over a bar. Bars disappear as the names of nations are clicked.](images/gdp.gif){:width="500px"}
 
 Hover the mouse over the biggest bars and notice which countries they belong to. Click the names of the really big ones to remove them from the chart; that will let you take a closer look at the others. Did any of the richest countries' teams have very large numbers of medals?
 
-### What did you find?
-
-What did you discover by using your program to look at this data?
-
-- There are some signs that the number of people a team has to choose from helps it earn medals.
-- But population doesn't explain how countries like France have so many medals. Or why India doesn't have as many medals as China or the USA.
-- Money seems to explain more. Most of the countries that have lots of medals have high GDPs too.
-- Neither of them explains everything. There are teams that don't follow this pattern.
+> [!INFO]
+>
+> ## What did you find?
+>
+> What did you discover by using your program to look at this data?
+>
+>  - There are some signs that the number of people a team has to choose from helps it earn medals.
+>  - But population doesn't explain how countries like France have so many medals. Or why India doesn't have as many medals as China or the USA.
+>  - Money seems to explain more. Most of the countries that have lots of medals have high GDPs too.
+>  - Neither of them explains everything. There are teams that don't follow this pattern.
 
 > [!ACCORDION] Jamaica does better than bigger and richer countries
 >

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -1,6 +1,6 @@
 ## Challenge
 
-Upgrade your project with a pie chart
+Upgrade your project with a pie chart.
 
 In this step, change how your chart looks, or what data it uses.
 
@@ -22,8 +22,8 @@ In this step, change how your chart looks, or what data it uses.
 >
 > Pick a different datafile for your project. There are two available:
 >
-> - `mcu.csv` is the runtime and gross income from the Marvel Cinematic Universe films
-> - `carbon.csv` is the total (thousands of tons) and per-person (tons) carbon dioxide emissions of different countries and regions
+>  - `mcu.csv` is the runtime and gross income from the Marvel Cinematic Universe films
+>  - `carbon.csv` is the total (thousands of tons) and per-person (tons) carbon dioxide emissions of different countries and regions
 >
 > Update the code that reads from `medals.csv` to read from your new file.
 >


### PR DESCRIPTION
Corrects two systematic errors in the earlier conversion (currently on `master`):

1. **Multi-task steps** now use `## Step 1`, `## Step 2` headings (were wrongly `### descriptive` sub-headings, losing the numbered-step structure). Steps 1, 2, 4 are multi-task.
2. **`## Now run your code`** restored on all 8 build steps (the source `**Test:**` run sections had been stripped to bare prose — none had the heading).

Also:
- Descriptive/discussion sections → `> [!INFO]` boxes ("Who has the most medals?", "Wealth", "What did you find?"), box titles as `## Title`
- step_7 `adjust_chart.gif` alt text: "populations" → "medals" (it's the medals chart there)
- step_1's pre-provided pygal import kept as context, not a step

🤖 Generated with [Claude Code](https://claude.com/claude-code)