### PR TITLE
Set listed: false (keep charting-champions unpublished)

### DIFF
--- a/en/meta.yml
+++ b/en/meta.yml
@@ -7,7 +7,7 @@ description:
 meta_title: Python coding projects for kids and teens | Charting champions
 meta_description: Learn Python with the Raspberry Pi Foundation's coding projects for kids and teens. Discover the power of lists in Python by creating a chart of Olympic medals.
 version: 4
-listed: true
+listed: false
 copyedit: true
 last_tested: "2021-10-07"
 landing: true


### PR DESCRIPTION
The RPF conversion merge inadvertently carried the draft's `listed: true` (from the earlier LandingStripper migration) onto `master`, **publishing this project**. It was meant to stay unpublished (it's flagged `needs_review` for poor quality). This sets `listed: false` again.

**Please merge to unpublish it** — it's currently live on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)